### PR TITLE
Test: Serve client from server side to bypass IOS third-party cookie restriction

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -33,7 +33,7 @@ app.use(
 );
 app.use(express.json());
 app.use(cookieParser());
-app.use(express.static("api/public"));
+app.use("/api/static", express.static("api/public"));
 app.use(express.static("client/dist"));
 
 // Routes

--- a/api/index.js
+++ b/api/index.js
@@ -6,8 +6,10 @@ import authRouter from "./routes/auth.route.js";
 import listingRouter from "./routes/listing.route.js";
 import cookieParser from "cookie-parser";
 import cors from "cors";
+import path from "path";
 
 const app = express();
+const __dirname = path.resolve();
 
 // Set up port
 const PORT = process.env.PORT || 3000;
@@ -32,11 +34,17 @@ app.use(
 app.use(express.json());
 app.use(cookieParser());
 app.use(express.static("api/public"));
+app.use(express.static("client/dist"));
 
 // Routes
 app.use("/api/user", userRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/listing", listingRouter);
+
+// Route to serve client
+app.get("*", (req, res) => {
+  res.sendFile(path.join(__dirname, "client/dist/index.html"));
+});
 
 // Error handling
 app.use((err, req, res, next) => {

--- a/api/models/user.model.js
+++ b/api/models/user.model.js
@@ -20,7 +20,7 @@ const userSchema = new Schema(
     },
     photoURL: {
       type: String,
-      default: "/default-profile-photo.png",
+      default: "/api/static/default-profile-photo.png",
     },
   },
   { timestamps: true }

--- a/client/src/components/ContactLandlord.jsx
+++ b/client/src/components/ContactLandlord.jsx
@@ -16,10 +16,9 @@ export default function ContactLandlord({ listing }) {
   useEffect(() => {
     const getLandlord = async () => {
       try {
-        const res = await fetch(
-          `${import.meta.env.VITE_SERVER_BASE_URL}/api/user/${userRef}`,
-          { credentials: "include" }
-        );
+        const res = await fetch("/api/user/${userRef}", {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -74,13 +74,7 @@ export default function Header() {
           <Link to="/profile">
             <img
               className="w-7 sm:w-8 lg:w-9 h-7 sm:h-8 lg:h-9 rounded-full object-cover"
-              src={
-                currentUser.photoURL === "/default-profile-photo.png"
-                  ? `${
-                      import.meta.env.VITE_SERVER_BASE_URL
-                    }/default-profile-photo.png`
-                  : currentUser.photoURL
-              }
+              src={currentUser.photoURL}
               alt="Profile photo"
             />
           </Link>

--- a/client/src/components/OAuth.jsx
+++ b/client/src/components/OAuth.jsx
@@ -16,21 +16,18 @@ export default function OAuth() {
       const result = await signInWithPopup(auth, provider);
       const user = result.user; // The signed-in user info
       const { displayName: username, email, photoURL } = user;
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/auth/google-sign-in`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            username,
-            email,
-            photoURL,
-          }),
-          credentials: "include",
-        }
-      );
+      const res = await fetch("/api/auth/google-sign-in", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username,
+          email,
+          photoURL,
+        }),
+        credentials: "include",
+      });
       const data = await res.json();
 
       if (res.ok) {

--- a/client/src/pages/CreateListing.jsx
+++ b/client/src/pages/CreateListing.jsx
@@ -155,17 +155,14 @@ export default function CreateListing() {
   // Side effects
   useEffect(() => {
     const makeCreateListingRequest = async () => {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/listing/create`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ ...formData, userRef: currentUser._id }),
-          credentials: "include",
-        }
-      );
+      const res = await fetch("/api/listing/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ ...formData, userRef: currentUser._id }),
+        credentials: "include",
+      });
       const data = await res.json();
 
       if (res.ok) {

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -21,12 +21,9 @@ export default function Home() {
 
     const fetchListingsWithOffer = async () => {
       try {
-        const res = await fetch(
-          `${
-            import.meta.env.VITE_SERVER_BASE_URL
-          }/api/listing/search?offer=true&limit=4`,
-          { credentials: "include" }
-        );
+        const res = await fetch("/api/listing/search?offer=true&limit=4", {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {
@@ -50,12 +47,9 @@ export default function Home() {
     };
     const fetchListingsForRent = async () => {
       try {
-        const res = await fetch(
-          `${
-            import.meta.env.VITE_SERVER_BASE_URL
-          }/api/listing/search?type=rent&limit=4`,
-          { credentials: "include" }
-        );
+        const res = await fetch("/api/listing/search?type=rent&limit=4", {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {
@@ -75,12 +69,9 @@ export default function Home() {
     };
     const fetchListingsForSale = async () => {
       try {
-        const res = await fetch(
-          `${
-            import.meta.env.VITE_SERVER_BASE_URL
-          }/api/listing/search?type=sale&limit=4`,
-          { credentials: "include" }
-        );
+        const res = await fetch("/api/listing/search?type=sale&limit=4", {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {

--- a/client/src/pages/Listing.jsx
+++ b/client/src/pages/Listing.jsx
@@ -43,10 +43,9 @@ export default function Listing() {
       setLoading(true);
 
       try {
-        const res = await fetch(
-          `${import.meta.env.VITE_SERVER_BASE_URL}/api/listing/get/${id}`,
-          { credentials: "include" }
-        );
+        const res = await fetch("/api/listing/get/${id}", {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {

--- a/client/src/pages/Listings.jsx
+++ b/client/src/pages/Listings.jsx
@@ -33,9 +33,7 @@ export default function Listings() {
   const handleConfirmDelete = async () => {
     try {
       const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/listing/delete/${
-          deleteRequest.listingId
-        }`,
+        `/api/listing/delete/${deleteRequest.listingId}`,
         { method: "DELETE", credentials: "include" }
       );
       const data = await res.json();
@@ -71,12 +69,9 @@ export default function Listings() {
       setError(null);
 
       try {
-        const res = await fetch(
-          `${import.meta.env.VITE_SERVER_BASE_URL}/api/user/listings/${id}`,
-          {
-            credentials: "include",
-          }
-        );
+        const res = await fetch(`/api/user/listings/${id}`, {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -117,15 +117,10 @@ export default function Profile() {
   };
   const handleConfirmDelete = async () => {
     try {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/user/delete/${
-          currentUser._id
-        }`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
+      const res = await fetch(`/api/user/delete/${currentUser._id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
 
       const data = await res.json();
 
@@ -153,13 +148,10 @@ export default function Profile() {
   };
   const handleSignOut = async () => {
     try {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/auth/sign-out`,
-        {
-          method: "POST",
-          credentials: "include",
-        }
-      );
+      const res = await fetch("/api/auth/sign-out", {
+        method: "POST",
+        credentials: "include",
+      });
       const data = await res.json();
 
       if (res.ok) {
@@ -231,19 +223,14 @@ export default function Profile() {
 
   useEffect(() => {
     const makeUpdateUserRequest = async () => {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/user/update/${
-          currentUser._id
-        }`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(formData),
-          credentials: "include",
-        }
-      );
+      const res = await fetch(`/api/user/update/${currentUser._id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+        credentials: "include",
+      });
       const data = await res.json();
 
       if (res.ok) {
@@ -299,14 +286,7 @@ export default function Profile() {
             />
             <img
               className="w-24 h-24 rounded-full object-cover self-center cursor-pointer"
-              src={
-                formData.photoURL ||
-                (currentUser.photoURL === "/default-profile-photo.png"
-                  ? `${
-                      import.meta.env.VITE_SERVER_BASE_URL
-                    }/default-profile-photo.png`
-                  : currentUser.photoURL)
-              }
+              src={formData.photoURL || currentUser.photoURL}
               alt="Profile photo"
               onClick={handleImgClick}
             />

--- a/client/src/pages/SearchListings.jsx
+++ b/client/src/pages/SearchListings.jsx
@@ -110,12 +110,9 @@ export default function SearchListings() {
       setError(null);
 
       try {
-        const res = await fetch(
-          `${
-            import.meta.env.VITE_SERVER_BASE_URL
-          }/api/listing/search?${newQueryString}`,
-          { credentials: "include" }
-        );
+        const res = await fetch(`/api/listing/search?${newQueryString}`, {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {
@@ -160,12 +157,9 @@ export default function SearchListings() {
       setLoading(true);
 
       try {
-        const res = await fetch(
-          `${import.meta.env.VITE_SERVER_BASE_URL}/api/listing/search${
-            location.search
-          }`,
-          { credentials: "include" }
-        );
+        const res = await fetch(`/api/listing/search${location.search}`, {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -61,17 +61,14 @@ export default function SignIn() {
 
   useEffect(() => {
     const makeSignInRequest = async () => {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/auth/sign-in`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(formData),
-          credentials: "include",
-        }
-      );
+      const res = await fetch("/api/auth/sign-in", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+        credentials: "include",
+      });
       const data = await res.json();
 
       if (res.ok) {

--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -77,17 +77,14 @@ export default function SignUp() {
 
   useEffect(() => {
     const makeSignUpRequest = async () => {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/auth/sign-up`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(formData),
-          credentials: "include",
-        }
-      );
+      const res = await fetch("/api/auth/sign-up", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+        credentials: "include",
+      });
 
       if (res.ok) {
         dispatch(signUpSuccess());

--- a/client/src/pages/UpdateListing.jsx
+++ b/client/src/pages/UpdateListing.jsx
@@ -160,10 +160,9 @@ export default function UpdateListing() {
   useEffect(() => {
     const getListing = async () => {
       try {
-        const res = await fetch(
-          `${import.meta.env.VITE_SERVER_BASE_URL}/api/listing/get/${id}`,
-          { credentials: "include" }
-        );
+        const res = await fetch(`/api/listing/get/${id}`, {
+          credentials: "include",
+        });
         const data = await res.json();
 
         if (res.ok) {
@@ -184,17 +183,14 @@ export default function UpdateListing() {
 
   useEffect(() => {
     const makeUpdateListingRequest = async () => {
-      const res = await fetch(
-        `${import.meta.env.VITE_SERVER_BASE_URL}/api/listing/update/${id}`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(formData),
-          credentials: "include",
-        }
-      );
+      const res = await fetch(`/api/listing/update/${id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+        credentials: "include",
+      });
       const data = await res.json();
 
       if (res.ok) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon api/index.js",
-    "start": "node api/index.js"
+    "start": "node api/index.js",
+    "build": "npm install && npm install --prefix client && npm run build --prefix client"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Problem: Cookies not working on IOS devices due to their "Prevent Cross-Site Tracking" security feature

Solution: Serve client from server side, so that client and server are on the same domain

Explanation: This bypasses the third-party cookie restriction because cookies are now considered "first-party" as they originate from the same domain